### PR TITLE
Fix IDP URL construction

### DIFF
--- a/Kernel/System/Auth/SAML2SP/AuthRequest.pm
+++ b/Kernel/System/Auth/SAML2SP/AuthRequest.pm
@@ -51,8 +51,8 @@ sub create{
 	my $base64_request = encode_base64($deflated_request);
 	
 	my $encoded_request = uri_escape($base64_request);
-	
-    return $self->{settings}->{idp_sso_target_url}."?SAMLRequest=".$encoded_request;
+	my $sep = index($self->{settings}->{idp_sso_target_url}, '?') == -1 ? '?' : '&';
+    return $self->{settings}->{idp_sso_target_url}.$sep."SAMLRequest=".$encoded_request;
 }
 
 


### PR DESCRIPTION
Check if SSOIdpUrl contains a query string and use the appropriate separator when appending the SAMLRequest parameter.

An example of SSOIdpUrl with a query string:
https://accounts.google.com/o/saml2/idp?idpid=D312ih566